### PR TITLE
Flb/execflow pipelines

### DIFF
--- a/ontoconv/pipelines.py
+++ b/ontoconv/pipelines.py
@@ -124,12 +124,23 @@ def save_simulation_resource(ts: Triplestore, iri: str, resource: dict):
         iri: IRI of the simulation tool.
         siminfo: A dict with the documentation to save.
     """
+    # pylint: disable=redefined-builtin
+
     # TODO: Since simulation resources are classes in the KB, the
     # correct way would be to add the additional documentation as
     # restrictions.
     # What we do here, will be interpreted as annotation properties
     # by Protege.
     save_container(ts, resource, iri, recognised_keys=RECOGNISED_KEYS)
+
+    # Ensure that all input and output are datasets
+    for input in resource.get("input"):
+        for dataset in input:
+            ts.add((dataset, RDF.type, OTEIO.DataSink))
+
+    for output in resource.get("output"):
+        for dataset in output:
+            ts.add((dataset, RDF.type, OTEIO.DataSource))
 
 
 def load_simulation_resource(ts: Triplestore, iri: str):

--- a/ontoconv/pipelines.py
+++ b/ontoconv/pipelines.py
@@ -205,8 +205,9 @@ def generate_ontoflow_pipeline(
 
     Arguments:
         ts: Tripper triplestore documenting data sources and sinks.
-        resources: A dict referring to OTEAPI partial pipelines for a set of data
-            source and sinks.  Se the example below for the expected structure.
+        resources: A dict referring to OTEAPI partial pipelines for
+            a set of data sources and sinks.
+            See the example below for the expected structure.
         client_iri: IRI of OTELib client to use.
 
     Returns:
@@ -217,22 +218,27 @@ def generate_ontoflow_pipeline(
 
         ```python
         {'sinks': [
-           {'iri': 'ss3:AbaqusConfiguration', 'resourcetype': 'ss3:AbaqusSimulation'},
-           {'iri': 'ss3:AluminiumMaterialCard', 'resourcetype': 'ss3:AbaqusSimulation'},
-           {'iri': 'ss3:ConcreteMaterialCard', 'resourcetype': 'ss3:AbaqusSimulation'}],
+           {'iri': 'ss3:AbaqusConfiguration',
+            'resourcetype': 'ss3:AbaqusSimulation'},
+           {'iri': 'ss3:AluminiumMaterialCard',
+            'resourcetype': 'ss3:AbaqusSimulation'},
+           {'iri': 'ss3:ConcreteMaterialCard',
+            'resourcetype': 'ss3:AbaqusSimulation'}],
          'sources': [
            {'iri': 'ss3kb:abaqus_config1', 'resourcetype': 'dataset'},
-           {'iri': 'ss3:AluminiumMaterialCard', 'resourcetype': 'ss3:MaterialCardGenerator'},
-           {'iri': 'ss3kb:abaqus_materialcard_concrete1', 'resourcetype': 'dataset'}]}
+           {'iri': 'ss3:AluminiumMaterialCard',
+            'resourcetype': 'ss3:MaterialCardGenerator'},
+           {'iri': 'ss3kb:abaqus_materialcard_concrete1',
+            'resourcetype': 'dataset'}]}
         ```
     """
-    names = []
+    names = {"input": [], "output": []}
     strategies = []
 
     lst = [("output", s) for s in resources.get("sources", [])]
     lst.extend([("input", s) for s in resources.get("sinks", [])])
-
-    for type, dct in lst:
+    i = 1
+    for dtype, dct in lst:
         iri = dct["iri"]
         resourcetype = dct["resourcetype"]
         suffix = (
@@ -241,21 +247,23 @@ def generate_ontoflow_pipeline(
         if resourcetype == "dataset":
             resource = load_container(ts, iri, recognised_keys=recognised_keys)
         else:
-            r = load_container(
-                ts, resourcetype, recognised_keys=recognised_keys
-            )
-            resource = r.get(type, [])
+            r = load_simulation_resource(ts, resourcetype)
+            resource = r[dtype]["ss3:" + suffix]
         for strategy in resource:
             for stype, conf in strategy.items():
-                name = f"{suffix}_{stype}"
-                d = {stype: name}
-                d.update(conf)
-            names.append(name)
-            strategies.append(d)
+                name = f"{suffix}_{stype}_{i}"
+                conf[stype] = name
+                i += 1
+                names[dtype].append(name)
+                strategies.append(conf)
     return {
         "version": 1,
         "strategies": strategies,
-        "pipelines": {"pipe": " | ".join(names)},
+        "pipelines": {
+            "pipe": " | ".join(names["output"])
+            + " | "
+            + " | ".join(names["input"])
+        },
     }
 
 

--- a/ontoconv/pipelines.py
+++ b/ontoconv/pipelines.py
@@ -307,11 +307,12 @@ def add_execflow_decoration_to_pipeline(strategies, names):
     # file to AiiDA datanode.
     func = [f for f in functions if f["function"] in names["input"]]
 
-    locations = (
+    locations = set(
         f["configuration"]["location"]
         for f in func
         if "location" in f["configuration"]
     )
+    print(locations)
 
     numfile = 1
     labels = []

--- a/ontoconv/pipelines.py
+++ b/ontoconv/pipelines.py
@@ -21,6 +21,8 @@ RECOGNISED_KEYS.update(
         "aiida_plugin": "http://open-model.eu/ontologies/oip#AiidaPlugin",
         "command": "http://open-model.eu/ontologies/oip#Command",
         "files": "http://open-model.eu/ontologies/oip#Files",
+        "input": "http://open-model.eu/ontologies/oip#SimulationToolInput",
+        "output": "http://open-model.eu/ontologies/oip#SimulationToolOutput",
         "install_command": (
             "http://open-model.eu/ontologies/oip#InstallCommand"
         ),

--- a/ontoconv/pipelines.py
+++ b/ontoconv/pipelines.py
@@ -248,7 +248,7 @@ def generate_ontoflow_pipeline(
             resource = load_container(ts, iri, recognised_keys=recognised_keys)
         else:
             r = load_simulation_resource(ts, resourcetype)
-            resource = r[dtype]["ss3:" + suffix]
+            resource = r[dtype]["ss3:" + suffix]  # KRISE,hardkodet!
         for strategy in resource:
             for stype, conf in strategy.items():
                 name = f"{suffix}_{stype}_{i}"

--- a/ontoconv/pipelines.py
+++ b/ontoconv/pipelines.py
@@ -251,7 +251,12 @@ def generate_ontoflow_pipeline(
             try:
                 resource = r[dtype][iri]
             except KeyError:
-                resource = r[dtype][ts.prefix_iri(iri)]
+                try:
+                    resource = r[dtype][ts.prefix_iri(iri)]
+                except KeyError as exc:
+                    raise KeyError(
+                        f"Could not find {dtype} {iri} in {r['iri']}"
+                    ) from exc
         for strategy in resource:
             for stype, conf in strategy.items():
                 name = f"{suffix}_{stype}_{i}"
@@ -261,6 +266,8 @@ def generate_ontoflow_pipeline(
                 strategies.append(conf)
 
     strategies, names = add_execflow_decoration_to_pipeline(strategies, names)
+    # if len(strategies["sinks"]) == 0:
+    #
 
     return {
         "version": 1,

--- a/ontoconv/pipelines.py
+++ b/ontoconv/pipelines.py
@@ -312,7 +312,6 @@ def add_execflow_decoration_to_pipeline(strategies, names):
         for f in func
         if "location" in f["configuration"]
     )
-    print(locations)
 
     numfile = 1
     labels = []

--- a/ontoconv/pipelines.py
+++ b/ontoconv/pipelines.py
@@ -302,8 +302,8 @@ def add_execflow_decoration_to_pipeline(strategies, names):
                 names["output"].insert(0, "datanode2cuds")
                 break
 
-    # Add cuds2datanode if not already present, if functions are present
-    # in the sink strategies. Also add corresponing functions to convert
+    # Add cuds2datanode if not already present, and files are created
+    # in the sink strategies. Also add corresponding functions to convert
     # file to AiiDA datanode.
     func = [f for f in functions if f["function"] in names["input"]]
 

--- a/ontoconv/pipelines.py
+++ b/ontoconv/pipelines.py
@@ -255,7 +255,7 @@ def generate_ontoflow_pipeline(
                     resource = r[dtype][ts.prefix_iri(iri)]
                 except KeyError as exc:
                     raise KeyError(
-                        f"Could not find {dtype} {iri} in {r['iri']}"
+                        f"Could not find {dtype} {iri} in {resourcetype}"
                     ) from exc
         for strategy in resource:
             for stype, conf in strategy.items():

--- a/ontoconv/pipelines.py
+++ b/ontoconv/pipelines.py
@@ -248,7 +248,10 @@ def generate_ontoflow_pipeline(
             resource = load_container(ts, iri, recognised_keys=recognised_keys)
         else:
             r = load_simulation_resource(ts, resourcetype)
-            resource = r[dtype]["ss3:" + suffix]  # KRISE,hardkodet!
+            try:
+                resource = r[dtype][iri]
+            except KeyError:
+                resource = r[dtype][ts.prefix_iri(iri)]
         for strategy in resource:
             for stype, conf in strategy.items():
                 name = f"{suffix}_{stype}_{i}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     #"ExecFlow @ git+https://github.com/H2020-OpenModel/ExecFlow",
     #"tripper >=0.2.15,<1",
     # NB!minimum version tripper should be 0.2.17
-    "tripper @ git+https://github.com/EMMC-ASBL/tripper.git@fix-convert",
+    "tripper @ git+https://github.com/EMMC-ASBL/tripper.git@master",
     "rdflib ~=7.0",
     "pyyaml ~=6.0",
     #"oteapi-core >=0.6.1,<0.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     #"OntoFlow @ git+https://github.com/H2020-OpenModel/OntoFlow",
     #"ExecFlow @ git+https://github.com/H2020-OpenModel/ExecFlow",
     #"tripper >=0.2.15,<1",
-    "tripper @ git+https://github.com/EMMC-ASBL/tripper",
+    "tripper @ git+https://github.com/EMMC-ASBL/tripper#egg=fix-convert",
     "rdflib ~=7.0",
     "pyyaml ~=6.0",
     "oteapi-core >=0.6.1,<0.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,11 @@ dependencies = [
     #"OntoFlow @ git+https://github.com/H2020-OpenModel/OntoFlow",
     #"ExecFlow @ git+https://github.com/H2020-OpenModel/ExecFlow",
     #"tripper >=0.2.15,<1",
-    "tripper @ git+https://github.com/EMMC-ASBL/tripper#egg=fix-convert",
+    "tripper @ git+https://github.com/EMMC-ASBL/tripper.git@fix-convert",
     "rdflib ~=7.0",
     "pyyaml ~=6.0",
-    "oteapi-core >=0.6.1,<0.7",
-    "otelib >=0.4.1,<0.5",
+    #"oteapi-core >=0.6.1,<0.7",
+    #"otelib >=0.4.1,<0.5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     #"OntoFlow @ git+https://github.com/H2020-OpenModel/OntoFlow",
     #"ExecFlow @ git+https://github.com/H2020-OpenModel/ExecFlow",
     #"tripper >=0.2.15,<1",
+    # NB!minimum version tripper should be 0.2.17
     "tripper @ git+https://github.com/EMMC-ASBL/tripper.git@fix-convert",
     "rdflib ~=7.0",
     "pyyaml ~=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "rdflib ~=7.0",
     "pyyaml ~=6.0",
     #"oteapi-core >=0.6.1,<0.7",
-    #"otelib >=0.4.1,<0.5",
+    "otelib >=0.4.1,<0.5",
 ]
 
 [project.optional-dependencies]

--- a/tests/input/resources.yaml
+++ b/tests/input/resources.yaml
@@ -11,31 +11,6 @@ prefixes:
 # knowledge base.
 data_resources:
 
-  # ------- Just stubs sufficiently for OntoFlow -------
-  ss3:fenics_finite_element_mesh:
-    - dataresource:
-        type: ["oteio:DataSink", "ss3:FenicsFiniteElementMesh"]
-
-  ss3:fenics_materials:
-    - dataresource:
-        type: ["oteio:DataSink", "ss3:FenicsMaterials"]
-
-  ss3:fenics_simulation_config:
-    - dataresource:
-        type: ["oteio:DataSink", "ss3:FenicsSimulationConfig"]
-
-  ss3:abaqus_finite_element_mesh:
-    - dataresource:
-        type: ["oteio:DataSink", "ss3:AbaqusFiniteElementMesh"]
-
-  ss3:abaqus_simple_material_card_template:
-    - dataresource:
-        type: ["oteio:DataSink", "ss3:AbaqusSimpleMaterialCardTemplate"]
-
-
-
-  # ------- More complete data resources -------
-
   # Load aluminium material card
   http://open-model.eu/ontologies/ss3#aluminium_material_card:
     - dataresource:
@@ -62,20 +37,6 @@ data_resources:
           - ["amc:Stress_plastic", "map:mapsTo", "micro:PlasticStress"]
           - ["amc:Yield_stress",   "map:mapsTo", "micro:YieldStress"]
 
-
-  # Create the material card input file for Abaqus
-  http://open-model.eu/ontologies/ss3#create_abaqus_input_material_card:
-    - function:
-        functionType: application/vnd.dlite-generate
-        configuration:
-          driver: plugin_abaqus_material
-          # the name of the file is as expected by the Abaqus input template
-          location: Section_materials.inp
-          # the option indicates that we want to write a new file and the header
-          options: "mode=w"
-          label: materialcard_al
-
-
   # Load material for concrete
   http://open-model.eu/ontologies/ss3#concrete_material_card:
     - dataresource:
@@ -86,42 +47,6 @@ data_resources:
          label: materialcard_concrete
          metadata: http://www.sintef.no/calm/0.1/AbaqusSimpleMaterialCard
          driver: "json"
-
-
-  # FIXME - update MaterialCardGenerator instead of appending to existing file
-  # Append to material card input file for Abaqus
-  http://open-model.eu/ontologies/ss3#append_abaqus_input_material_card:
-    - function:
-       functionType: application/vnd.dlite-generate
-       configuration:
-         driver: plugin_abaqus_material
-         # the name of the file is as expected by the Abaqus input template
-         location: Section_materials.inp
-         # the option indicates that we do not write the header
-         options: "mode=a"
-         label: materialcard_concrete
-
-
-  # Create the AiiDA SingleFile nodes in two steps through a Dlite collection
-  # Step1 file stored in a dlite collection
-  http://open-model.eu/ontologies/ss3#file2collection_mat:
-    - function:
-       functionType: aiidacuds/file2collection
-       configuration:
-         path: Section_materials.inp
-         label: material_file
-
-
-  # Step 2 convert the file to an AiiDA node
-  # specific to execution with execflow
-  # the variable names defined in the declarative workflow should correspond to the label "material_file"
-  # from_cuds is not really a label you can't change it is a hard-coded thing
-  http://open-model.eu/ontologies/ss3#cuds2datanode:
-    - function:
-       functionType: aiidacuds/cuds2datanode
-       configuration:
-         names: from_cuds
-
 
 simulation_resources:
 

--- a/tests/input/resources.yaml
+++ b/tests/input/resources.yaml
@@ -138,6 +138,28 @@ simulation_resources:
         source_uri: "file://path/to/file"
       - filename: the_name_of_second_file.json
         source_uri: "file://path/to/second/file"
+    input:
+      ss3:AluminiumMaterialCard:
+        - function:
+            functionType: application/vnd.dlite-generate
+            configuration:
+              driver: plugin_abaqus_material
+              # the name of the file is as expected by the Abaqus input template
+              location: Section_materials.inp
+              datamodel: http://www.sintef.no/calm/0.1/AluminiumMaterialCard
+    output:
+      ss3:AbaqusDeformationHistory:
+        - function:
+            functionType: application/vnd.dlite-convert
+            configuration:
+              module_name: ss3_wrappers.abaqus_convert
+              function_name: abaqus_converter
+              inputs:
+                - label: cement_output
+                  datamodel: http://onto-ns.com/meta/2.0/core.singlefile
+              outputs:
+                - label: cement_output_instance
+                  datamodel: http://www.sintef.no/calm/0.1/AbaqusDeformationHistory
 
     # The commands for installing the wrapper for the simulation tool
     install_command: |

--- a/tests/test_2_generate_pipeline.py
+++ b/tests/test_2_generate_pipeline.py
@@ -18,25 +18,53 @@ def test_generate_pipeline():
         ts,
         steps=[
             SS3.aluminium_material_card,
-            SS3.create_abaqus_input_material_card,
             SS3.concrete_material_card,
-            SS3.append_abaqus_input_material_card,
         ],
     )
 
     with open(outdir / "pipeline.yml", "w", encoding="utf8") as f:
         yaml.safe_dump(pipeline, f, sort_keys=False)
 
-    pipeline2 = generate_pipeline(
-        ts,
-        steps=[
-            SS3.aluminium_material_card,
-            SS3.create_abaqus_input_material_card,
-            SS3.concrete_material_card,
-            SS3.append_abaqus_input_material_card,
-            SS3.file2collection_mat,
-            SS3.cuds2datanode,
+
+def test_generate_execflow_pipeline():
+    """Test generating declarative pipeline."""
+    import yaml
+    from paths import outdir
+    from tripper import Triplestore
+
+    from ontoconv.pipelines import generate_ontoflow_pipeline
+
+    ts = Triplestore(backend="rdflib")
+    ts.parse(outdir / "kb.ttl")
+
+    resources = {
+        "sinks": [
+            {
+                "iri": "http://open-model.eu/ontologies/ss3"
+                "#AluminiumMaterialCard",
+                "resourcetype": "http://open-model.eu/ontologies/ss3"
+                "#AbaqusSimulation",
+            },
         ],
+        "sources": [
+            {
+                "iri": "http://open-model.eu/ontologies/ss3"
+                "#AbaqusDeformationHistory",
+                "resourcetype": "http://open-model.eu/ontologies/ss3"
+                "#AbaqusSimulation",
+            },
+            {
+                "iri": "http://open-model.eu/ontologies/ss3"
+                "#concrete_material_card",
+                "resourcetype": "dataset",
+            },
+        ],
+    }
+
+    pipeline = generate_ontoflow_pipeline(
+        ts,
+        resources=resources,
     )
+
     with open(outdir / "pipeline2.yml", "w", encoding="utf8") as f:
-        yaml.safe_dump(pipeline2, f, sort_keys=False)
+        yaml.safe_dump(pipeline, f, sort_keys=False)

--- a/tests/test_3_generate_workchain.py
+++ b/tests/test_3_generate_workchain.py
@@ -14,7 +14,7 @@ def test_load_simulation_resource():
     SS3 = ts.namespaces["ss3"]
     resource = load_simulation_resource(ts, SS3.AbaqusSimulation)
 
-    assert resource.files == [
+    assert resource.files == [  # pylint: disable=no-member
         {
             "filename": "the_name_of_the_file.txt",
             "source_uri": "file://path/to/file",
@@ -24,45 +24,44 @@ def test_load_simulation_resource():
             "source_uri": "file://path/to/second/file",
         },
     ]
-    assert resource.input == {
+    assert resource.input == {  # pylint: disable=no-member
         "ss3:AluminiumMaterialCard": [
             {
-                "function": {
-                    "configuration": {
-                        "location": "Section_materials.inp",
-                        "datamodel": "http://www.sintef.no/calm/0.1/"
-                        "AluminiumMaterialCard",
-                        "driver": "plugin_abaqus_material",
-                    },
-                    "functionType": "application/vnd.dlite-generate",
-                }
+                "function": None,
+                "functionType": "application/vnd.dlite-generate",
+                "configuration": {
+                    "datamodel": "http://www.sintef.no/calm/0.1/"
+                    "AluminiumMaterialCard",
+                    "driver": "plugin_abaqus_material",
+                    "location": "Section_materials.inp",
+                },
             }
         ]
     }
-    assert resource.output == {
+
+    assert resource.output == {  # pylint: disable=no-member
         "ss3:AbaqusDeformationHistory": [
             {
-                "function": {
-                    "configuration": {
-                        "module_name": "ss3_wrappers.abaqus_convert",
-                        "outputs": [
-                            {
-                                "label": "cement_output_instance",
-                                "datamodel": "http://www.sintef.no/calm/0.1/"
-                                "AbaqusDeformationHistory",
-                            }
-                        ],
-                        "inputs": [
-                            {
-                                "label": "cement_output",
-                                "datamodel": "http://onto-ns.com/meta/2.0/"
-                                "core.singlefile",
-                            }
-                        ],
-                        "function_name": "abaqus_converter",
-                    },
-                    "functionType": "application/vnd.dlite-convert",
-                }
+                "functionType": "application/vnd.dlite-convert",
+                "function": None,
+                "configuration": {
+                    "outputs": [
+                        {
+                            "label": "cement_output_instance",
+                            "datamodel": "http://www.sintef.no/calm/0.1/"
+                            "AbaqusDeformationHistory",
+                        }
+                    ],
+                    "inputs": [
+                        {
+                            "label": "cement_output",
+                            "datamodel": "http://onto-ns.com/meta/2.0/"
+                            "core.singlefile",
+                        }
+                    ],
+                    "function_name": "abaqus_converter",
+                    "module_name": "ss3_wrappers.abaqus_convert",
+                },
             }
         ]
     }

--- a/tests/test_3_generate_workchain.py
+++ b/tests/test_3_generate_workchain.py
@@ -14,10 +14,58 @@ def test_load_simulation_resource():
     SS3 = ts.namespaces["ss3"]
     resource = load_simulation_resource(ts, SS3.AbaqusSimulation)
 
-    print("need to check content of resource.files, check issue #11")
-    # assert resource.files == ?
-    # assert resource.output ==
-    # assert resrouce.input ==
+    assert resource.files == [
+        {
+            "filename": "the_name_of_the_file.txt",
+            "source_uri": "file://path/to/file",
+        },
+        {
+            "filename": "the_name_of_second_file.json",
+            "source_uri": "file://path/to/second/file",
+        },
+    ]
+    assert resource.input == {
+        "ss3:AluminiumMaterialCard": [
+            {
+                "function": {
+                    "configuration": {
+                        "location": "Section_materials.inp",
+                        "datamodel": "http://www.sintef.no/calm/0.1/"
+                        "AluminiumMaterialCard",
+                        "driver": "plugin_abaqus_material",
+                    },
+                    "functionType": "application/vnd.dlite-generate",
+                }
+            }
+        ]
+    }
+    assert resource.output == {
+        "ss3:AbaqusDeformationHistory": [
+            {
+                "function": {
+                    "configuration": {
+                        "module_name": "ss3_wrappers.abaqus_convert",
+                        "outputs": [
+                            {
+                                "label": "cement_output_instance",
+                                "datamodel": "http://www.sintef.no/calm/0.1/"
+                                "AbaqusDeformationHistory",
+                            }
+                        ],
+                        "inputs": [
+                            {
+                                "label": "cement_output",
+                                "datamodel": "http://onto-ns.com/meta/2.0/"
+                                "core.singlefile",
+                            }
+                        ],
+                        "function_name": "abaqus_converter",
+                    },
+                    "functionType": "application/vnd.dlite-convert",
+                }
+            }
+        ]
+    }
 
     assert resource.aiida_plugin == "execwrapper"
     assert resource.command == "run_abaqus.sh"

--- a/tests/test_3_generate_workchain.py
+++ b/tests/test_3_generate_workchain.py
@@ -14,8 +14,10 @@ def test_load_simulation_resource():
     SS3 = ts.namespaces["ss3"]
     resource = load_simulation_resource(ts, SS3.AbaqusSimulation)
 
-    print("need to check content of resource.files")
+    print("need to check content of resource.files, check issue #11")
     # assert resource.files == ?
+    # assert resource.output ==
+    # assert resrouce.input ==
 
     assert resource.aiida_plugin == "execwrapper"
     assert resource.command == "run_abaqus.sh"

--- a/tests/test_3_generate_workchain.py
+++ b/tests/test_3_generate_workchain.py
@@ -27,13 +27,14 @@ def test_load_simulation_resource():
     assert resource.input == {  # pylint: disable=no-member
         "ss3:AluminiumMaterialCard": [
             {
-                "function": None,
-                "functionType": "application/vnd.dlite-generate",
-                "configuration": {
-                    "datamodel": "http://www.sintef.no/calm/0.1/"
-                    "AluminiumMaterialCard",
-                    "driver": "plugin_abaqus_material",
-                    "location": "Section_materials.inp",
+                "function": {
+                    "functionType": "application/vnd.dlite-generate",
+                    "configuration": {
+                        "datamodel": "http://www.sintef.no/calm/0.1/"
+                        "AluminiumMaterialCard",
+                        "driver": "plugin_abaqus_material",
+                        "location": "Section_materials.inp",
+                    },
                 },
             }
         ]
@@ -42,25 +43,26 @@ def test_load_simulation_resource():
     assert resource.output == {  # pylint: disable=no-member
         "ss3:AbaqusDeformationHistory": [
             {
-                "functionType": "application/vnd.dlite-convert",
-                "function": None,
-                "configuration": {
-                    "outputs": [
-                        {
-                            "label": "cement_output_instance",
-                            "datamodel": "http://www.sintef.no/calm/0.1/"
-                            "AbaqusDeformationHistory",
-                        }
-                    ],
-                    "inputs": [
-                        {
-                            "label": "cement_output",
-                            "datamodel": "http://onto-ns.com/meta/2.0/"
-                            "core.singlefile",
-                        }
-                    ],
-                    "function_name": "abaqus_converter",
-                    "module_name": "ss3_wrappers.abaqus_convert",
+                "function": {
+                    "functionType": "application/vnd.dlite-convert",
+                    "configuration": {
+                        "outputs": [
+                            {
+                                "label": "cement_output_instance",
+                                "datamodel": "http://www.sintef.no/calm/0.1/"
+                                "AbaqusDeformationHistory",
+                            }
+                        ],
+                        "inputs": [
+                            {
+                                "label": "cement_output",
+                                "datamodel": "http://onto-ns.com/meta/2.0/"
+                                "core.singlefile",
+                            }
+                        ],
+                        "function_name": "abaqus_converter",
+                        "module_name": "ss3_wrappers.abaqus_convert",
+                    },
                 },
             }
         ]


### PR DESCRIPTION
In order for ExecFlow to use the oteapi pipelines, some extra "decoration" is needed around the pipelines.

If any of the sources is a function, it means that it takes some input from AiiDA which was generated in the previous step of ExecFlow. In this case "datanode2cuds" must be added as a strategy in the beginning of the pipeline.

If any othe sinks create files to be passed on to the next step in ExecFlow, strategies for passing these files to the collection and on as an aiida data node with cuds2datanode is added. Note that there is an issue with labelas that need to be aligned with the labels used in the declarative workchain. 